### PR TITLE
removes redundant definition of DB constant from spc file (DB defined…

### DIFF
--- a/spec/student_spec.rb
+++ b/spec/student_spec.rb
@@ -1,8 +1,8 @@
 require_relative 'spec_helper'
+require 'pry'
 
 describe Student do
   before :each do
-    DB = {:conn => SQLite3::Database.new("db/students.db")}
     DB[:conn].execute("DROP TABLE IF EXISTS students")
 
     sql = <<-SQL


### PR DESCRIPTION
… in config/environment.rb)
There was an error saying that DB was already defined.  Removing this line from the spec file resolves the error and shows test output as normal.